### PR TITLE
Fix FPS tracking logic

### DIFF
--- a/pkg/game/game.go
+++ b/pkg/game/game.go
@@ -59,11 +59,9 @@ func (g *Game) Run(window *glfw.Window, scene *scene.SceneB) error {
 	window.SetCursorPos(float64(g.ScreenWidth)/2, float64(g.ScreenHeight)/2)
 
 	deltaTime := 0.0
+	seconds := 0.0
+	fps := 0.0
 	for !g.Window.ShouldClose() {
-
-		// Statistics
-		seconds := 0.0
-		fps := 0.0
 
 		program.Clear()
 


### PR DESCRIPTION
## Summary
- fix FPS/seconds counters resetting inside the main loop

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68607b66c79083299a3695eadd76d284